### PR TITLE
Update pigpio.html

### DIFF
--- a/proof-of-concept/pigpio.html
+++ b/proof-of-concept/pigpio.html
@@ -3,20 +3,8 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-        <title>python workers</title>
-        <script type="importmap">
-            {
-                "imports": {
-                    "basic-devtools": "/pyscript.core/node_modules/basic-devtools/esm/index.js",
-                    "coincident/structured": "/pyscript.core/node_modules/coincident/structured.js",
-                    "@ungap/with-resolvers": "/pyscript.core/node_modules/@ungap/with-resolvers/index.js",
-                    "@pyscript/core": "/pyscript.core/esm/index.js"
-                }
-            }
-        </script>
-        <script type="module">
-            import "@pyscript/core";
-        </script>
+        <title>pyscript pigpio</title>
+        <script type="module" src="/pyscript.core/min.js"></script>
     </head>
     <body>
       <script type="py" config="./pigpio.toml">


### PR DESCRIPTION
For distributed demo I suggest to use the pre-compiled, optimized, version of the current core, not its dev environment. That allows you to also trim down files needed in the repo (i.e. the whole esm folder is not necessary at all, neither is the rest).